### PR TITLE
fix: Symbolics Differential(::Number)

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,10 +1,19 @@
 name: IntegrationTest
 on:
   push:
-    branches: [main]
-    tags: [v*]
+    tags:
+      - '*'
+    branches:
+      - 'main'
   pull_request:
-
+    branches:
+      - 'main'
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  
 jobs:
   test:
     name: ${{ matrix.package.repo }}/${{ matrix.julia-version }}

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 DocStringExtensions = "0.9.4"
 SymbolicUtils = "3.25"
-Symbolics = "~6.34"
+Symbolics = "6.34"
 julia = "1.10"
 Random = "1.10"
 LinearAlgebra = "1.10"

--- a/src/Symbolics/Symbolics_utils.jl
+++ b/src/Symbolics/Symbolics_utils.jl
@@ -51,7 +51,7 @@ function substitute_all(x::Subtype, rules::Dict; include_derivatives=true)
     if include_derivatives
         drules = Pair[]
         for var in keys(rules)
-            if !isa(rules[var], Union{AbstractFloat, Integer})
+            if !isa(rules[var], Union{AbstractFloat,Integer})
                 pair = Differential(var) => Differential(rules[var])
                 push!(drules, pair)
             end

--- a/src/Symbolics/Symbolics_utils.jl
+++ b/src/Symbolics/Symbolics_utils.jl
@@ -51,7 +51,7 @@ function substitute_all(x::Subtype, rules::Dict; include_derivatives=true)
     if include_derivatives
         drules = Pair[]
         for var in keys(rules)
-            if !isa(rules[var], Number)
+            if !isa(rules[var], Union{AbstractFloat, Integer})
                 pair = Differential(var) => Differential(rules[var])
                 push!(drules, pair)
             end

--- a/src/Symbolics/Symbolics_utils.jl
+++ b/src/Symbolics/Symbolics_utils.jl
@@ -49,10 +49,14 @@ Perform substitutions in `rules` on `x`.
 Subtype = Union{Num,Equation,BasicSymbolic}
 function substitute_all(x::Subtype, rules::Dict; include_derivatives=true)
     if include_derivatives
-        rules = merge(
-            rules,
-            Dict([Differential(var) => Differential(rules[var]) for var in keys(rules)]),
-        )
+        drules = Pair[]
+        for var in keys(rules)
+            if !isa(rules[var], Number)
+                pair = Differential(var) => Differential(rules[var])
+                push!(drules, pair)
+            end
+        end
+        rules = merge(rules, Dict(drules))
     end
     return substitute(x, rules)
 end

--- a/test/HarmonicVariable.jl
+++ b/test/HarmonicVariable.jl
@@ -69,7 +69,11 @@ end
     result = substitute_all(eq, rules)
     @eqtest result == new_var^2 + ω
 
-    # Test variable substitution
+    # Test number substitution
     new_hv = substitute_all(hv, Dict(ω => 2))
     @test new_hv.ω == 2
+
+    # Test variable substitution
+    new_hv = substitute_all(hv, Dict(ω => new_var))
+    @test isequal(new_hv.ω,new_var)
 end

--- a/test/HarmonicVariable.jl
+++ b/test/HarmonicVariable.jl
@@ -75,5 +75,5 @@ end
 
     # Test variable substitution
     new_hv = substitute_all(hv, Dict(ω => new_var))
-    @test isequal(new_hv.ω,new_var)
+    @test isequal(new_hv.ω, new_var)
 end

--- a/test/HarmonicVariable.jl
+++ b/test/HarmonicVariable.jl
@@ -73,3 +73,13 @@ end
     new_hv = substitute_all(hv, Dict(ω => 2))
     @test new_hv.ω == 2
 end
+# hv = HarmonicVariable(nat_var, "test_name", "u", ω, nat_var)
+# rules = Dict(ω => 2)
+# new_hv = substitute_all(hv, rules)
+# sym, freq = hv.symbol, hv.ω
+# substitute_all(sym, rules)
+# rules = merge(
+#     rules,
+#     Dict([Differential(var) => Differential(rules[var]) for var in keys(rules)]),
+# )
+# sym

--- a/test/HarmonicVariable.jl
+++ b/test/HarmonicVariable.jl
@@ -73,13 +73,3 @@ end
     new_hv = substitute_all(hv, Dict(ω => 2))
     @test new_hv.ω == 2
 end
-# hv = HarmonicVariable(nat_var, "test_name", "u", ω, nat_var)
-# rules = Dict(ω => 2)
-# new_hv = substitute_all(hv, rules)
-# sym, freq = hv.symbol, hv.ω
-# substitute_all(sym, rules)
-# rules = merge(
-#     rules,
-#     Dict([Differential(var) => Differential(rules[var]) for var in keys(rules)]),
-# )
-# sym


### PR DESCRIPTION
## Checklist

Thank you for contributing to `QuestBase.jl`! Please make sure you have finished the following tasks before finishing the PR.

- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

As of [this commit](https://github.com/JuliaSymbolics/Symbolics.jl/commit/b964f70b420ff0127b4d368e1451716c8aa6d822) Symbolics.jl doesn't support `Differential(::Number)` anymore. This PR solves this issue in `substitute_all`
