### PR TITLE
build: restore Julia 1.10 LTS support

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.12'
+          version: 'lts'
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -40,7 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12'
+          - 'lts'
+          - '1'
         os:
           - ubuntu-latest
         arch:
@@ -64,4 +65,4 @@ jobs:
           file: lcov.info
           name: codecov-umbrella
           fail_ci_if_error: false
-        if: ${{ matrix.version == '1.12' }}
+        if: ${{ matrix.version == 'lts' }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuestBase"
 uuid = "7e80f742-43d6-403d-a9ea-981410111d43"
 authors = ["Orjan Ameye <orjan.ameye@hotmail.com>", "Jan Kosata <kosataj@phys.ethz.ch>", "Javier del Pino <jdelpino@phys.ethz.ch>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -17,7 +17,7 @@ DocStringExtensions = "0.9.4"
 DynamicPolynomials = "0.6"
 SymbolicUtils = "4"
 Symbolics = "7"
-julia = "1.12"
+julia = "1.10"
 Random = "1.10"
 LinearAlgebra = "1.10"
 MultivariatePolynomials = "0.5"


### PR DESCRIPTION
Lowers `julia` compat back to `"1.10"` and restores `lts` in the `Tests.yml` matrix (`['lts', '1']`, with coverage uploaded from the lts job) and in `Documentation.yml`, matching the configuration before the Symbolics 7 migration.

All dependencies (Symbolics 7, SymbolicUtils 4, DynamicPolynomials, MultivariatePolynomials, OrderedCollections) still declare `julia = "1.10.0 - 1"`, and the full test suite passes locally on 1.10.11.

Version bumped to 0.4.2.