### PR TITLE
fix: give up on Bareiss solves that grow past what is workable

### DIFF
--- a/src/HarmonicEquation.jl
+++ b/src/HarmonicEquation.jl
@@ -208,6 +208,10 @@ function rearrange!(eom::HarmonicEquation, new_rhs::Vector{Num})
         )
         Symbolics.simplify_fractions.(Num.(fallback))
     end
+    # SymbolicUtils 4 leaves `cos(x)^2 + sin(x)^2` standing, and these solutions carry the
+    # coefficient determinant in their denominator, so without collapsing it the expressions
+    # grow every time a system is rearranged.
+    soln = collapse_pythagorean.(soln)
     soln = reduce_denominator.(soln)
     eom.equations = soln .~ new_rhs
     return nothing

--- a/src/QuestBase.jl
+++ b/src/QuestBase.jl
@@ -40,6 +40,7 @@ using Symbolics:
 include("utils.jl")
 include("Symbolics/Symbolics_utils.jl")
 include("Symbolics/exponentials.jl")
+include("Symbolics/pythagorean.jl")
 include("Symbolics/fourier.jl")
 include("Symbolics/drop_powers.jl")
 include("Symbolics/linear_solve.jl")

--- a/src/Symbolics/linear_solve.jl
+++ b/src/Symbolics/linear_solve.jl
@@ -2,9 +2,75 @@ struct BareissFailure <: Exception
     message::String
 end
 
+"""
+Raised when Bareiss elimination is abandoned because its intermediate polynomials grew past
+what is workable, rather than because the system is unsuitable for it.
+
+This is deliberately *not* a [`BareissFailure`](@ref). A `BareissFailure` means the system is
+not polynomial in the unknowns, and `rearrange!` answers it by falling back to
+`Symbolics.symbolic_linear_solve`. Size is different: the LU fallback grows nested fractions
+on exactly the systems that overwhelm Bareiss, so it is no refuge. This propagates to the
+caller instead, letting one that has a cheaper route (`add_jacobian!` evaluates the Jacobian
+implicitly) take it.
+"""
+struct BareissTooLarge <: Exception
+    message::String
+end
+
 const _BAREISS_VARIABLE = only(DP.@polyvar __questbase_bareiss_variable)
 
+"""
+Largest number of monomials an intermediate Bareiss entry may reach before the solve gives
+up with a [`BareissFailure`](@ref).
+
+Bareiss is fraction-free, which is what lets it sidestep the nested-fraction growth of
+`Symbolics.symbolic_linear_solve`, but the entries it carries are exact polynomials whose
+degree grows with every pivot. On a dense system in many symbolic atoms, such as the
+harmonic equations of a van der Pol oscillator expanded in three harmonics, that growth is
+combinatorial and the solve never finishes even though nothing has gone wrong. Callers that
+have a cheaper option, such as evaluating a Jacobian implicitly, can catch the failure and
+take it.
+
+The systems this solve handles well stay far below the budget: 10 monomials for a Duffing
+oscillator, 28 for a parametron, 344 for a van der Pol with two harmonics. The budget has to
+be tight as well as safe, because the polynomial arithmetic is already slow at entry sizes
+well under it, so a generous budget takes minutes to trip.
+"""
+const BAREISS_TERM_BUDGET = Ref(2_000)
+
+"""
+Ceiling on the monomial count a single polynomial product may be predicted to reach.
+
+The size checks on finished entries are not enough on their own: one multiplication of two
+wide polynomials can exhaust memory before its result can be measured. The number of terms
+in a product is at most the product of the factors' term counts, so that bound is checked
+before multiplying. It is deliberately far looser than [`BAREISS_TERM_BUDGET`](@ref),
+because the bound is pessimistic and systems that solve fine reach it: a van der Pol with
+two harmonics multiplies 344-term entries, predicting over a hundred thousand terms for a
+result that is much smaller.
+"""
+const BAREISS_PRODUCT_BUDGET = Ref(4_000_000)
+
+"Number of monomials in a Bareiss entry; constants count as one."
+_bareiss_size(entry) = entry isa Number ? 1 : length(MP.terms(entry))
+
+"Multiply two Bareiss entries, refusing products predicted to be unmanageably wide."
+function _bareiss_product(left, right, pivot_index, n)
+    predicted = _bareiss_size(left) * _bareiss_size(right)
+    predicted > BAREISS_PRODUCT_BUDGET[] && throw(
+        BareissTooLarge(
+            "Bareiss product predicted at $(predicted) terms at pivot $(pivot_index) of " *
+            "$(n), over the $(BAREISS_PRODUCT_BUDGET[]) term product budget",
+        ),
+    )
+    return left * right
+end
+
 function Base.showerror(io::IO, error::BareissFailure)
+    return print(io, error.message)
+end
+
+function Base.showerror(io::IO, error::BareissTooLarge)
     return print(io, error.message)
 end
 
@@ -67,13 +133,23 @@ function _bareiss_jordan_solve(coefficients, right_hand_side)
             for column in axes(augmented, 2)
                 column == pivot_index && continue
                 numerator =
-                    pivot * old[row, column] -
-                    old[row, pivot_index] * old[pivot_index, column]
-                augmented[row, column] = if pivot_index == 1
+                    _bareiss_product(pivot, old[row, column], pivot_index, n) -
+                    _bareiss_product(
+                        old[row, pivot_index], old[pivot_index, column], pivot_index, n
+                    )
+                entry = if pivot_index == 1
                     numerator
                 else
                     _exact_polynomial_division(numerator, previous_pivot)
                 end
+                terms = _bareiss_size(entry)
+                terms > BAREISS_TERM_BUDGET[] && throw(
+                    BareissTooLarge(
+                        "Bareiss entry reached $(terms) terms at pivot $(pivot_index) of " *
+                        "$(n), over the $(BAREISS_TERM_BUDGET[]) term budget",
+                    ),
+                )
+                augmented[row, column] = entry
             end
             augmented[row, pivot_index] = 0
         end

--- a/src/Symbolics/pythagorean.jl
+++ b/src/Symbolics/pythagorean.jl
@@ -11,8 +11,9 @@ keeps those expressions small again, at the cost of one bottom-up walk, rather t
 exponential round trip [`trig_reduce`](@ref) needs.
 """
 collapse_pythagorean(x::Num) = wrap(collapse_pythagorean(unwrap(x)))
-collapse_pythagorean(x::Equation) =
-    Equation(collapse_pythagorean(x.lhs), collapse_pythagorean(x.rhs))
+function collapse_pythagorean(x::Equation)
+    return Equation(collapse_pythagorean(x.lhs), collapse_pythagorean(x.rhs))
+end
 function collapse_pythagorean(x)
     x isa BasicSymbolic || return x
     collapsed = Postwalk(_collapse_pythagorean_node)(x)
@@ -87,9 +88,9 @@ function _collapse_pythagorean_node(x)
                 j == i && return false
                 taken[j] && return false
                 isnothing(parts[j]) && return false
-                parts[j][1] === partner_operation &&
-                    isequal(parts[j][2], argument_i) &&
-                    isequal(parts[j][3], coefficient_i)
+                return parts[j][1] === partner_operation &&
+                       isequal(parts[j][2], argument_i) &&
+                       isequal(parts[j][3], coefficient_i)
             end
             if !isnothing(partner)
                 taken[i] = taken[partner] = true

--- a/src/Symbolics/pythagorean.jl
+++ b/src/Symbolics/pythagorean.jl
@@ -1,0 +1,106 @@
+"""
+    collapse_pythagorean(x)
+
+Collapse `cos(θ)^2 + sin(θ)^2` to `1` wherever the pair appears in a sum, including with a
+shared coefficient, as in `a*cos(θ)^2 + a*sin(θ)^2 => a`.
+
+SymbolicUtils 3 folded this identity away on its own. SymbolicUtils 4 does not, which is
+why the determinant-carrying denominators of a symbolic linear solve stopped simplifying
+and started growing without bound on a trigonometric ansatz. Applying the identity directly
+keeps those expressions small again, at the cost of one bottom-up walk, rather than the full
+exponential round trip [`trig_reduce`](@ref) needs.
+"""
+collapse_pythagorean(x::Num) = wrap(collapse_pythagorean(unwrap(x)))
+collapse_pythagorean(x::Equation) =
+    Equation(collapse_pythagorean(x.lhs), collapse_pythagorean(x.rhs))
+function collapse_pythagorean(x)
+    x isa BasicSymbolic || return x
+    collapsed = Postwalk(_collapse_pythagorean_node)(x)
+    return isnothing(collapsed) ? x : collapsed
+end
+
+"`cos`/`sin` and its argument if `x` is one of them, `nothing` otherwise."
+function _trig_operation(x)
+    (x isa BasicSymbolic && isterm(x)) || return nothing
+    op = operation(x)
+    (op === cos || op === sin) || return nothing
+    return op, first(arguments(x))
+end
+
+"Is `x` the literal exponent 2?"
+function _is_squared(x)
+    value = x isa BasicSymbolic ? unwrap_const(x) : x
+    return value isa Number && value == 2
+end
+
+"""
+Split a summand into `(cos-or-sin, argument, remaining factors)` when it carries a squared
+trig factor, `nothing` otherwise.
+"""
+function _squared_trig_term(summand)
+    if summand isa BasicSymbolic && ispow(summand)
+        base, exponent = arguments(summand)
+        _is_squared(exponent) || return nothing
+        trig = _trig_operation(base)
+        isnothing(trig) && return nothing
+        return trig[1], trig[2], Num(1)
+    elseif summand isa BasicSymbolic && ismul(summand)
+        trig = nothing
+        rest = Num(1)
+        for factor in arguments(summand)
+            if isnothing(trig) && factor isa BasicSymbolic && ispow(factor)
+                base, exponent = arguments(factor)
+                if _is_squared(exponent)
+                    candidate = _trig_operation(base)
+                    if !isnothing(candidate)
+                        trig = candidate
+                        continue
+                    end
+                end
+            end
+            rest *= wrap(factor)
+        end
+        isnothing(trig) && return nothing
+        return trig[1], trig[2], rest
+    end
+    return nothing
+end
+
+"Pair up squared sines and cosines among the summands of a single `Add` node."
+function _collapse_pythagorean_node(x)
+    (x isa BasicSymbolic && isadd(x)) || return x
+    summands = collect(arguments(x))
+    length(summands) > 1 || return x
+    parts = map(_squared_trig_term, summands)
+    any(!isnothing, parts) || return x
+
+    taken = falses(length(summands))
+    result = Num(0)
+    collapsed_any = false
+    for i in eachindex(summands)
+        taken[i] && continue
+        part = parts[i]
+        if !isnothing(part)
+            operation_i, argument_i, coefficient_i = part
+            partner_operation = operation_i === cos ? sin : cos
+            partner = findfirst(eachindex(summands)) do j
+                j == i && return false
+                taken[j] && return false
+                isnothing(parts[j]) && return false
+                parts[j][1] === partner_operation &&
+                    isequal(parts[j][2], argument_i) &&
+                    isequal(parts[j][3], coefficient_i)
+            end
+            if !isnothing(partner)
+                taken[i] = taken[partner] = true
+                result += coefficient_i
+                collapsed_any = true
+                continue
+            end
+        end
+        taken[i] = true
+        result += wrap(summands[i])
+    end
+    collapsed_any || return x
+    return unwrap(result)
+end


### PR DESCRIPTION
The limit cycle tutorial hangs. A van der Pol ansatz in three harmonics gives a
dense 6x6 whose Bareiss entries grow combinatorially, and one multiplication can
exhaust memory before its result can even be measured. Bound the predicted width
of a product before multiplying, and the width of a finished entry after. The
systems this solve handles well sit far below the bounds: 10 monomials for a
Duffing oscillator, 28 for a parametron, 344 for a van der Pol with two harmonics.

Size raises `BareissTooLarge`, not `BareissFailure`. They're different conditions:
`BareissFailure` means the system isn't polynomial in the unknowns and
`rearrange!` answers it with the LU fallback, but that fallback grows without
bound on exactly the systems that are too large for Bareiss. Size has to reach a
caller with a cheaper route instead, which HarmonicBalance's `add_jacobian!` now
is.

Second commit collapses `cos^2 + sin^2`, which SymbolicUtils 4 stopped folding.
It's correct and the equations are unchanged, but I measured no benefit: Krylov
order 2 goes 3.61s -> 3.43s, which is noise. Split out so it can be dropped.
